### PR TITLE
batch StableAsset mint & stake to Euphrates pool

### DIFF
--- a/src/IStaking.sol
+++ b/src/IStaking.sol
@@ -75,3 +75,15 @@ interface IStaking {
     /// @return Returns (success).
     function exit(uint256 poolId) external returns (bool);
 }
+
+/// @title IStakingTo Interface
+/// @author Acala Developers
+/// @notice You can use this integrate Acala LST staking into your contract.
+interface IStakingTo is IStaking {
+    /// @notice Stake share to other.
+    /// @param poolId The index of staking pool.
+    /// @param amount The share amount to stake.
+    /// @param receiver The share receiver.
+    /// @return Returns (success).
+    function stakeTo(uint256 poolId, uint256 amount, address receiver) external returns (bool);
+}

--- a/src/IWrappedStableAssetShare.sol
+++ b/src/IWrappedStableAssetShare.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+/// @title IWrappedStableAssetShare Interface
+/// @author Acala Developers
+/// @notice You can use this to wrapped stable asset pool LP token to received market profit.
+interface IWrappedStableAssetShare {
+    /// @notice Deposit share token to mint wrapped share token.
+    /// @param who The sender of the transaction.
+    /// @param shareAmount The share token amount to deposit.
+    /// @param wrappedShareAmount The wrapped share token amount received.
+    event Deposit(address indexed who, uint256 shareAmount, uint256 wrappedShareAmount);
+
+    /// @notice Withdraw share token by burn wrapped share token.
+    /// @param who The sender of the transaction.
+    /// @param wrappedShareAmount The wrapped share token amount to burn.
+    /// @param shareAmount The share token amount received.
+    event Withdraw(address indexed who, uint256 wrappedShareAmount, uint256 shareAmount);
+
+    /// @notice Get the deposit rate(the exchange rate for share token to wrapped share token).
+    /// @return Returns (exchangeRate). Deposit rate, 1e18 is 100%
+    function depositRate() external view returns (uint256);
+
+    /// @notice Get the withdraw rate(the exchange rate for wrapped share token to share token).
+    /// @return Returns (exchangeRate). Withdraw rate, 1e18 is 100%
+    function withdrawRate() external view returns (uint256);
+
+    /// @notice Deposit `shareAmount` share token to mint wrapped share token.
+    /// @param shareAmount The share token amount to deposit.
+    /// @return Returns (wrappedShareAmount). The wrapped share token amount received.
+    function deposit(uint256 shareAmount) external returns (uint256);
+
+    /// @notice Withdraw share token by burn `wrappedShareAmount` wrapped share token.
+    /// @param wrappedShareAmount The wrapped share token amount to burn.
+    /// @return Returns (shareAmount). The share token amount received.
+    function withdraw(uint256 wrappedShareAmount) external returns (uint256);
+}

--- a/src/StableAssetStakeUtil.sol
+++ b/src/StableAssetStakeUtil.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "@openzeppelin-contracts/utils/math/SafeMath.sol";
+import "@openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin-contracts/token/ERC20/IERC20.sol";
+import "@AcalaNetwork/predeploy-contracts/stable-asset/IStableAsset.sol";
+import "./IWrappedStableAssetShare.sol";
+import "./IStaking.sol";
+
+/// @title StableAssetStakeUtil Contract
+/// @author Acala Developers
+/// @notice Utilitity contract support batch these operation:
+/// 1. mint StaleAsset LP token
+/// 2. wrap LP token to Wrapped LP token
+/// 3. stake Wrapped LP token to Euphrates pool
+contract StableAssetStakeUtil {
+    using SafeMath for uint256;
+    using SafeERC20 for IERC20;
+
+    /// @notice The token address of Euphrates.
+    IStakingTo public immutable euphrates;
+
+    /// @notice The StableAsset predeploy contract address.
+    IStableAsset public immutable stableAsset;
+
+    /// @notice Deploys StableAssetStakeUtil contract.
+    /// @param euphratesAddr The contract address of Euphrates.
+    /// @param stableAssetAddress The contract address of StableAsset predeploy contract.
+    constructor(address euphratesAddr, address stableAssetAddress) {
+        euphrates = IStakingTo(euphratesAddr);
+        stableAsset = IStableAsset(stableAssetAddress);
+    }
+
+    /// @notice Mint StalbeAsset LP token and stake it's wrapped token to Euphrates pool.
+    /// @param stableAssetPoolId The id of StableAsset pool.
+    /// @param assetsAmount The amounts of assets of StableAsset pool used to mint.
+    /// @param stableAssetShareToken The LP token of StableAsset pool.
+    /// @param wrappedShareToken The wrapper for StableAsset LP token.
+    /// @param poolId The if of Euphrates pool.
+    /// @return Returns (success).
+    /// @dev it's not compitable with StableAsset TDOT pool becuase of the assets amount of LDOT is rebased.
+    function mintAndStake(
+        uint32 stableAssetPoolId,
+        uint256[] memory assetsAmount,
+        IERC20 stableAssetShareToken,
+        IWrappedStableAssetShare wrappedShareToken,
+        uint256 poolId
+    ) public returns (bool) {
+        // StableAsset check
+        (bool valid, address[] memory assets) = stableAsset.getStableAssetPoolTokens(stableAssetPoolId);
+        require(valid && assetsAmount.length == assets.length, "StableAssetStakeUtil: invalid stable asset pool");
+
+        // transfer assets from msg.sender
+        for (uint256 i = 0; i < assets.length; i++) {
+            if (assetsAmount[i] != 0) {
+                IERC20(assets[i]).safeTransferFrom(msg.sender, address(this), assetsAmount[i]);
+            }
+        }
+
+        // StableAsset mint, no need to approve assets to stable-asset
+        uint256 beforeStableAssetShareAmount = IERC20(stableAssetShareToken).balanceOf(address(this));
+
+        // NOTE: use assetsAmount as the params, it cannot used to StableAsset TDOT pool because TDOT pool mint params amount is rebased!
+        bool success = stableAsset.stableAssetMint(stableAssetPoolId, assetsAmount, 0);
+        require(success, "StableAssetStakeUtil: stable-asset mint failed");
+        uint256 afterStableAssetShareAmount = IERC20(stableAssetShareToken).balanceOf(address(this));
+        uint256 mintedShareAmount = afterStableAssetShareAmount.sub(beforeStableAssetShareAmount);
+        require(mintedShareAmount != 0, "StableAssetStakeUtil: zero minted share amount is not allowed");
+
+        // wrap share token
+        stableAssetShareToken.safeApprove(address(wrappedShareToken), mintedShareAmount);
+        uint256 wrappedShareAmount = wrappedShareToken.deposit(mintedShareAmount);
+        require(wrappedShareAmount != 0, "StableAssetStakeUtil: zero wrapped share amount is not allowed");
+
+        // stake wrapped share token to Euphrates pool
+        IERC20(address(wrappedShareToken)).safeApprove(address(euphrates), wrappedShareAmount);
+        return euphrates.stakeTo(poolId, wrappedShareAmount, msg.sender);
+    }
+}

--- a/src/UpgradeableStakingLST.sol
+++ b/src/UpgradeableStakingLST.sol
@@ -318,6 +318,7 @@ contract UpgradeableStakingLST is UpgradeableStakingCommon {
     /// @param amount The amount of share token to stake.
     function stake(uint256 poolId, uint256 amount)
         public
+        virtual
         override
         whenNotPaused
         poolOperationNotPaused(poolId, Operation.Stake)
@@ -380,6 +381,7 @@ contract UpgradeableStakingLST is UpgradeableStakingCommon {
     /// @return Returns (success).
     function unstake(uint256 poolId, uint256 amount)
         public
+        virtual
         override
         whenNotPaused
         poolOperationNotPaused(poolId, Operation.Unstake)

--- a/src/UpgradeableStakingLSTV2.sol
+++ b/src/UpgradeableStakingLSTV2.sol
@@ -8,24 +8,107 @@ import "./IStaking.sol";
 import "./UpgradeableStakingLST.sol";
 import "./WrappedTDOT.sol";
 
-/// @title IStakingTo Interface
-/// @author Acala Developers
-/// @notice You can use this integrate Acala LST staking into your contract.
-interface IStakingTo is IStaking {
-    /// @notice Stake share to other.
-    /// @param poolId The index of staking pool.
-    /// @param amount The share amount to stake.
-    /// @param receiver The share receiver.
-    /// @return Returns (success).
-    function stakeTo(uint256 poolId, uint256 amount, address receiver) external returns (bool);
-}
-
 /// @title UpgradeableStakingLSTV2 Contract
 /// @author Acala Developers
 /// @notice V2 version for UpgradeableStakingLST, support stake share to other.
 contract UpgradeableStakingLSTV2 is UpgradeableStakingLST, IStakingTo {
     using SafeMath for uint256;
     using SafeERC20 for IERC20;
+
+    /// @notice Stake `amount` share token to `poolId` pool. If pool has been converted, still stake before share token.
+    /// @param poolId The index of staking pool.
+    /// @param amount The amount of share token to stake.
+    function stake(uint256 poolId, uint256 amount)
+        public
+        virtual
+        override(UpgradeableStakingLST, IStaking)
+        whenNotPaused
+        poolOperationNotPaused(poolId, Operation.Stake)
+        updateRewards(poolId, msg.sender)
+        nonReentrant
+        returns (bool)
+    {
+        IERC20 shareType = shareTypes(poolId);
+        require(address(shareType) != address(0), "invalid pool");
+
+        uint256 addedShare;
+        ConvertInfo memory convertInfo = convertInfos(poolId);
+        if (address(convertInfo.convertedShareType) != address(0)) {
+            // if pool has converted, transfer the before share token to this firstly
+            shareType.safeTransferFrom(msg.sender, address(this), amount);
+
+            uint256 convertedAmount;
+            if (address(shareType) == LCDOT && address(convertInfo.convertedShareType) == LDOT) {
+                convertedAmount = _convertLCDOT2LDOT(amount);
+            } else if (address(shareType) == LCDOT && address(convertInfo.convertedShareType) == TDOT) {
+                convertedAmount = _convertLCDOT2TDOT(amount);
+            } else if (address(shareType) == DOT && address(convertInfo.convertedShareType) == LDOT) {
+                convertedAmount = _convertDOT2LDOT(amount);
+            } else if (address(shareType) == DOT && address(convertInfo.convertedShareType) == TDOT) {
+                convertedAmount = _convertDOT2TDOT(amount);
+            } else if (address(shareType) == LCDOT && address(convertInfo.convertedShareType) == WTDOT) {
+                uint256 tdotAmount = _convertLCDOT2TDOT(amount);
+                convertedAmount = _convertTDOT2WTDOT(tdotAmount);
+            } else if (address(shareType) == DOT && address(convertInfo.convertedShareType) == WTDOT) {
+                uint256 tdotAmount = _convertDOT2TDOT(amount);
+                convertedAmount = _convertTDOT2WTDOT(tdotAmount);
+            } else {
+                revert("unsupported converted share token");
+            }
+
+            // must convert the share amount according to the exchange rate of converted pool
+            addedShare = convertedAmount.mul(1e18).div(convertInfo.convertedExchangeRate);
+        } else {
+            // if pool hasn't converted, stake it directly
+            shareType.safeTransferFrom(msg.sender, address(this), amount);
+            addedShare = amount;
+        }
+
+        require(addedShare > 0, "cannot stake 0");
+        _totalShares[poolId] = _totalShares[poolId].add(addedShare);
+        _shares[poolId][msg.sender] = _shares[poolId][msg.sender].add(addedShare);
+
+        emit Stake(msg.sender, poolId, addedShare);
+
+        return true;
+    }
+
+    /// @notice Unstake `amount` share token from `poolId` pool.
+    /// @param poolId The index of staking pool.
+    /// @param amount The share token amount to unstake. If pool has been converted, it's converted share token amount, not the share amount.
+    /// @return Returns (success).
+    function unstake(uint256 poolId, uint256 amount)
+        public
+        virtual
+        override(UpgradeableStakingLST, IStaking)
+        whenNotPaused
+        poolOperationNotPaused(poolId, Operation.Unstake)
+        updateRewards(poolId, msg.sender)
+        nonReentrant
+        returns (bool)
+    {
+        require(amount > 0, "cannot unstake 0");
+        IERC20 shareType = shareTypes(poolId);
+        require(address(shareType) != address(0), "invalid pool");
+        require(_shares[poolId][msg.sender] >= amount, "share not enough");
+
+        _totalShares[poolId] = _totalShares[poolId].sub(amount);
+        _shares[poolId][msg.sender] = _shares[poolId][msg.sender].sub(amount);
+
+        ConvertInfo memory convertInfo = convertInfos(poolId);
+        if (address(convertInfo.convertedShareType) != address(0)) {
+            uint256 convertedAmount = amount.mul(convertInfo.convertedExchangeRate).div(1e18);
+            require(convertedAmount != 0, "shouldn't be zero");
+
+            convertInfo.convertedShareType.safeTransfer(msg.sender, convertedAmount);
+        } else {
+            shareType.safeTransfer(msg.sender, amount);
+        }
+
+        emit Unstake(msg.sender, poolId, amount);
+
+        return true;
+    }
 
     /// @inheritdoc IStakingTo
     function stakeTo(uint256 poolId, uint256 amount, address receiver)
@@ -70,10 +153,6 @@ contract UpgradeableStakingLSTV2 is UpgradeableStakingLST, IStakingTo {
 
             // must convert the share amount according to the exchange rate of converted pool
             addedShare = convertedAmount.mul(1e18).div(convertInfo.convertedExchangeRate);
-        } else if (address(shareType) == WTDOT) {
-            // transfer TDOT to this, convert it to WTDOT and stake it
-            IERC20(TDOT).safeTransferFrom(msg.sender, address(this), amount);
-            addedShare = _convertTDOT2WTDOT(amount);
         } else {
             // if pool hasn't converted, stake it directly
             shareType.safeTransferFrom(msg.sender, address(this), amount);

--- a/src/WrappedTUSD.sol
+++ b/src/WrappedTUSD.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "@openzeppelin-contracts/utils/math/SafeMath.sol";
+import "@openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin-contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin-contracts/security/ReentrancyGuard.sol";
+import "solmate/tokens/ERC20.sol";
+
+import "./IWrappedStableAssetShare.sol";
+
+/// @title WrappedTUSD Contract
+/// @author Acala Developers
+/// @notice To wrap TUSD, TUSD is the LP token of Taiga's StableAsset(USDCet-USDT) pool on Acala. The TUSD holders
+/// can receive TUSD as the LP fee by claim. So WTUSD and TUSD do not maintain a 1:1 ratio.
+contract WrappedTUSD is IWrappedStableAssetShare, ERC20, ReentrancyGuard {
+    using SafeMath for uint256;
+    using SafeERC20 for IERC20;
+
+    /// @notice The token address of TUSD.
+    address public immutable tusd;
+
+    /// @notice Deploys WTUSD token.
+    /// @param tusdAddr The token address of TUSD.
+    constructor(address tusdAddr) ERC20("Wrapped TUSD", "WTUSD", 6) {
+        tusd = tusdAddr;
+    }
+
+    /// @inheritdoc IWrappedStableAssetShare
+    function depositRate() public view returns (uint256) {
+        uint256 tusdAmount = IERC20(tusd).balanceOf(address(this));
+        uint256 wtusdAmount = totalSupply;
+
+        if (wtusdAmount == 0 || tusdAmount == 0) {
+            return 1e18;
+        } else {
+            return wtusdAmount.mul(1e18).div(tusdAmount);
+        }
+    }
+
+    /// @inheritdoc IWrappedStableAssetShare
+    function withdrawRate() public view returns (uint256) {
+        uint256 tusdAmount = IERC20(tusd).balanceOf(address(this));
+        uint256 wtusdAmount = totalSupply;
+
+        if (wtusdAmount == 0) {
+            return 0;
+        } else {
+            return tusdAmount.mul(1e18).div(wtusdAmount);
+        }
+    }
+
+    /// @inheritdoc IWrappedStableAssetShare
+    function deposit(uint256 tusdAmount) public returns (uint256) {
+        uint256 wtusdAmount = tusdAmount.mul(depositRate()).div(1e18);
+        require(wtusdAmount != 0, "WTUSD: invalid WTUSD amount");
+
+        IERC20(tusd).safeTransferFrom(msg.sender, address(this), tusdAmount);
+        _mint(msg.sender, wtusdAmount);
+
+        emit Deposit(msg.sender, tusdAmount, wtusdAmount);
+        return wtusdAmount;
+    }
+
+    /// @inheritdoc IWrappedStableAssetShare
+    function withdraw(uint256 wtusdAmount) public returns (uint256) {
+        require(balanceOf[msg.sender] >= wtusdAmount, "WTUSD: WTUSD not enough");
+        uint256 tusdAmount = wtusdAmount.mul(withdrawRate()).div(1e18);
+        require(tusdAmount != 0, "WTUSD: invalid TUSD amount");
+
+        _burn(msg.sender, wtusdAmount);
+        IERC20(tusd).safeTransfer(msg.sender, tusdAmount);
+
+        emit Withdraw(msg.sender, wtusdAmount, tusdAmount);
+        return tusdAmount;
+    }
+}

--- a/test/MockStableAsset.sol
+++ b/test/MockStableAsset.sol
@@ -113,3 +113,130 @@ contract MockStableAsset is IStableAsset {
         revert("MockStableAsset: unimplement");
     }
 }
+
+contract MockStableAssetV2 is IStableAsset {
+    using SafeMath for uint256;
+
+    address public immutable DOT;
+    address public immutable LDOT;
+    address public immutable TDOT;
+    address public immutable HOMA;
+    address public immutable USDCET;
+    address public immutable USDT;
+    address public immutable TUSD;
+
+    constructor(address dot, address ldot, address tdot, address homa, address usdcet, address usdt, address tusd) {
+        DOT = dot;
+        LDOT = ldot;
+        TDOT = tdot;
+        HOMA = homa;
+        USDCET = usdcet;
+        USDT = usdt;
+        TUSD = tusd;
+    }
+
+    function getStableAssetPoolTokens(uint32 poolId) external view returns (bool, address[] memory) {
+        if (poolId == 0) {
+            address[] memory assets = new address[](2);
+            assets[0] = DOT;
+            assets[1] = LDOT;
+            return (true, assets);
+        } else if (poolId == 1) {
+            address[] memory assets = new address[](2);
+            assets[0] = USDCET;
+            assets[1] = USDT;
+            return (true, assets);
+        } else {
+            address[] memory assets = new address[](0);
+            return (true, assets);
+        }
+    }
+
+    function getStableAssetPoolTotalSupply(uint32 poolId) external view returns (bool, uint256) {
+        revert("MockStableAsset: unimplement");
+    }
+
+    function getStableAssetPoolPrecision(uint32 poolId) external view returns (bool, uint256) {
+        revert("MockStableAsset: unimplement");
+    }
+
+    function getStableAssetPoolMintFee(uint32 poolId) external view returns (bool, uint256) {
+        revert("MockStableAsset: unimplement");
+    }
+
+    function getStableAssetPoolSwapFee(uint32 poolId) external view returns (bool, uint256) {
+        revert("MockStableAsset: unimplement");
+    }
+
+    function getStableAssetPoolRedeemFee(uint32 poolId) external view returns (bool, uint256) {
+        revert("MockStableAsset: unimplement");
+    }
+
+    function stableAssetSwap(uint32 poolId, uint32 i, uint32 j, uint256 dx, uint256 minDY, uint32 assetLength)
+        external
+        returns (bool)
+    {
+        revert("MockStableAsset: unimplement");
+    }
+
+    function stableAssetMint(uint32 poolId, uint256[] calldata amounts, uint256 minMintAmount)
+        external
+        returns (bool)
+    {
+        if (poolId == 0) {
+            require(amounts.length == 2, "MockStableAsset: invalid amounts length");
+            uint256 dotAmount = amounts[0];
+            uint256 rebasedLdotAmount = amounts[1];
+
+            if (dotAmount == 0 && rebasedLdotAmount == 0) {
+                revert("MockStableAsset: invalid amounts");
+            }
+
+            uint256 ldotAmount = rebasedLdotAmount.mul(1e18).div(IHoma(HOMA).getExchangeRate());
+            MockToken(DOT).forceTransfer(msg.sender, address(this), dotAmount);
+            MockToken(LDOT).forceTransfer(msg.sender, address(this), ldotAmount);
+
+            // set DOT mint tDOT at 1:1, and LDOT mint tDOT at 1:10
+            uint256 tdotAmount = dotAmount.add(ldotAmount.div(10));
+            MockToken(TDOT).mint(msg.sender, tdotAmount);
+        } else if (poolId == 1) {
+            require(amounts.length == 2, "MockStableAsset: invalid amounts length");
+            require(amounts[0] != 0 || amounts[1] != 0, "MockStableAsset: invalid amounts");
+
+            MockToken(USDCET).forceTransfer(msg.sender, address(this), amounts[0]);
+            MockToken(USDT).forceTransfer(msg.sender, address(this), amounts[1]);
+
+            // set USDCET mint TUSD at 1:1, and USDT mint TUSD at 1:1
+            uint256 tusdAmount = amounts[0].add(amounts[1]);
+            MockToken(TUSD).mint(msg.sender, tusdAmount);
+        } else {
+            revert("MockStableAsset: invalid pool");
+        }
+
+        return true;
+    }
+
+    function stableAssetRedeem(uint32 poolId, uint256 redeemAmount, uint256[] calldata amounts)
+        external
+        returns (bool)
+    {
+        revert("MockStableAsset: unimplement");
+    }
+
+    function stableAssetRedeemSingle(
+        uint32 poolId,
+        uint256 redeemAmount,
+        uint32 i,
+        uint256 minRedeemAmount,
+        uint32 assetLength
+    ) external returns (bool) {
+        revert("MockStableAsset: unimplement");
+    }
+
+    function stableAssetRedeemMulti(uint32 poolId, uint256[] calldata amounts, uint256 maxRedeemAmount)
+        external
+        returns (bool)
+    {
+        revert("MockStableAsset: unimplement");
+    }
+}

--- a/test/StableAssetStakeUtil.t.sol
+++ b/test/StableAssetStakeUtil.t.sol
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "@openzeppelin-contracts/token/ERC20/IERC20.sol";
+import "../src/StableAssetStakeUtil.sol";
+import "../src/UpgradeableStakingLSTV2.sol";
+import "../src/WrappedTDOT.sol";
+import "../src/WrappedTUSD.sol";
+import "../src/IWrappedStableAssetShare.sol";
+import "./MockHoma.sol";
+import "./MockLiquidCrowdloan.sol";
+import "./MockStableAsset.sol";
+import "./MockToken.sol";
+
+contract StableAssetStakeUtilTest is Test {
+    using stdStorage for StdStorage;
+
+    event LSTPoolConverted(
+        uint256 poolId,
+        IERC20 beforeShareType,
+        IERC20 afterShareType,
+        uint256 beforeShareTokenAmount,
+        uint256 afterShareTokenAmount
+    );
+    event Unstake(address indexed account, uint256 poolId, uint256 amount);
+    event Stake(address indexed account, uint256 poolId, uint256 amount);
+    event ClaimReward(address indexed account, uint256 poolId, IERC20 indexed rewardType, uint256 amount);
+
+    UpgradeableStakingLSTV2 public staking;
+    MockHoma public homa;
+    MockStableAssetV2 public stableAsset;
+    MockLiquidCrowdloan public liquidCrowdloan;
+    IERC20 public dot;
+    IERC20 public ldot;
+    IERC20 public lcdot;
+    IERC20 public tdot;
+    IERC20 public usdcet;
+    IERC20 public usdt;
+    IERC20 public tusd;
+    WrappedTDOT public wtdot;
+    WrappedTUSD public wtusd;
+    StableAssetStakeUtil public util;
+    address public ADMIN = address(0x1111);
+    address public ALICE = address(0x2222);
+    address public BOB = address(0x3333);
+
+    function setUp() public {
+        dot = IERC20(address(new MockToken("Acala DOT", "DOT", 1_000_000_000 ether)));
+        lcdot = IERC20(address(new MockToken("Acala LcDOT", "LcDOT", 1_000_000_000 ether)));
+        ldot = IERC20(address(new MockToken("Acala LDOT", "LDOT", 1_000_000_000 ether)));
+        tdot = IERC20(address(new MockToken("Taiga tDOT", "tDOT", 1_000_000_000 ether)));
+        usdcet = IERC20(address(new MockToken("Wormhole USDCet", "USDCet", 1_000_000_000 ether)));
+        usdt = IERC20(address(new MockToken("Aasset Hub USDT", "USDT", 1_000_000_000 ether)));
+        tusd = IERC20(address(new MockToken("Taiga tUSD", "tUSD", 1_000_000_000 ether)));
+
+        homa = new MockHoma(address(dot), address(ldot));
+        stableAsset = new MockStableAssetV2(
+            address(dot),
+            address(ldot),
+            address(tdot),
+            address(homa),
+            address(usdcet),
+            address(usdt),
+            address(tusd)
+        );
+        liquidCrowdloan = new MockLiquidCrowdloan(
+            address(lcdot),
+            address(dot),
+            1e18
+        );
+        wtdot = new WrappedTDOT(address(tdot));
+        wtusd = new WrappedTUSD(address(tusd));
+
+        staking = new UpgradeableStakingLSTV2();
+        vm.prank(ADMIN);
+        staking.initialize(
+            address(dot),
+            address(lcdot),
+            address(ldot),
+            address(tdot),
+            address(homa),
+            address(stableAsset),
+            address(liquidCrowdloan),
+            address(wtdot)
+        );
+
+        util = new StableAssetStakeUtil(
+            address(staking),
+            address(stableAsset)
+        );
+    }
+
+    function test_mintAndStake_revertInvalidStableAssetPool() public {
+        vm.prank(ADMIN);
+        staking.addPool(IERC20(address(wtusd)));
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 0;
+        amounts[1] = 0;
+        vm.expectRevert("StableAssetStakeUtil: invalid stable asset pool");
+        util.mintAndStake(2, amounts, tusd, wtusd, 0);
+    }
+
+    function test_mintAndStake_revertInvalidAssetsAmount() public {
+        vm.prank(ADMIN);
+        staking.addPool(IERC20(address(wtusd)));
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 0;
+        amounts[1] = 0;
+        vm.expectRevert("MockStableAsset: invalid amounts");
+        util.mintAndStake(1, amounts, tusd, wtusd, 0);
+    }
+
+    function test_mintAndStake_revertZeroMintedShareAmount() public {
+        usdcet.transfer(ALICE, 1_000_000 ether);
+        usdt.transfer(ALICE, 1_000_000 ether);
+        vm.prank(ADMIN);
+        staking.addPool(IERC20(address(wtusd)));
+
+        vm.startPrank(ALICE);
+        usdcet.approve(address(util), 1_000_000 ether);
+        usdt.approve(address(util), 1_000_000 ether);
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 1_000_000 ether;
+        amounts[1] = 1_000_000 ether;
+        vm.expectRevert("StableAssetStakeUtil: zero minted share amount is not allowed");
+
+        // StableAsset pool#1's share token is tUSD, not tDOT
+        util.mintAndStake(1, amounts, tdot, wtusd, 0);
+    }
+
+    function test_mintAndStake_revertZeroWrappedShareTokenAmount() public {
+        usdcet.transfer(ALICE, 1_000_000 ether);
+        usdt.transfer(ALICE, 1_000_000 ether);
+        vm.prank(ADMIN);
+        staking.addPool(IERC20(address(wtusd)));
+
+        vm.startPrank(ALICE);
+        usdcet.approve(address(util), 1_000_000 ether);
+        usdt.approve(address(util), 1_000_000 ether);
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 1_000_000 ether;
+        amounts[1] = 1_000_000 ether;
+        vm.expectRevert(stdError.arithmeticError);
+
+        // tUSD can be wrapper by WTUSD, not WTDOT
+        util.mintAndStake(1, amounts, tusd, IWrappedStableAssetShare(address(wtdot)), 0);
+    }
+
+    function test_mintAndStake_revertEuphratesPoolNotMatch() public {
+        usdcet.transfer(ALICE, 1_000_000 ether);
+        usdt.transfer(ALICE, 1_000_000 ether);
+        vm.prank(ADMIN);
+        staking.addPool(tusd);
+
+        vm.startPrank(ALICE);
+        usdcet.approve(address(util), 1_000_000 ether);
+        usdt.approve(address(util), 1_000_000 ether);
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 1_000_000 ether;
+        amounts[1] = 1_000_000 ether;
+        vm.expectRevert(stdError.arithmeticError);
+
+        // Euphrates pool#0's share token is tUSD, not WTUSD
+        util.mintAndStake(1, amounts, tusd, wtusd, 0);
+    }
+
+    function test_mintAndStake_works() public {
+        usdcet.transfer(ALICE, 1_000_000 ether);
+        usdt.transfer(ALICE, 1_000_000 ether);
+        vm.prank(ADMIN);
+        staking.addPool(IERC20(address(wtusd)));
+
+        assertEq(usdcet.balanceOf(ALICE), 1_000_000 ether);
+        assertEq(usdt.balanceOf(ALICE), 1_000_000 ether);
+        assertEq(tusd.balanceOf(ALICE), 0);
+        assertEq(wtusd.balanceOf(ALICE), 0);
+        assertEq(tusd.balanceOf(address(staking)), 0);
+        assertEq(wtusd.balanceOf(address(staking)), 0);
+        assertEq(tusd.balanceOf(address(wtusd)), 0);
+        assertEq(IERC20(address(wtusd)).totalSupply(), 0);
+
+        // ALICE mint tUSD and stake to WTUSD pool by StableAssetStakeUtil.mintAndStake
+        vm.startPrank(ALICE);
+        usdcet.approve(address(util), 1_000_000 ether);
+        usdt.approve(address(util), 1_000_000 ether);
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 1_000_000 ether;
+        amounts[1] = 1_000_000 ether;
+        emit Stake(ALICE, 0, 2_000_000 ether);
+        util.mintAndStake(1, amounts, tusd, wtusd, 0);
+        vm.stopPrank();
+
+        assertEq(usdcet.balanceOf(ALICE), 0);
+        assertEq(usdt.balanceOf(ALICE), 0);
+        assertEq(tusd.balanceOf(ALICE), 0);
+        assertEq(wtusd.balanceOf(ALICE), 0);
+        assertEq(tusd.balanceOf(address(staking)), 0);
+        assertEq(wtusd.balanceOf(address(staking)), 2_000_000 ether);
+        assertEq(tusd.balanceOf(address(wtusd)), 2_000_000 ether);
+        assertEq(IERC20(address(wtusd)).totalSupply(), 2_000_000 ether);
+
+        // mock the hold TUSD increased of WrappedTUSD
+        tusd.transfer(address(wtusd), 500_000 ether);
+        assertEq(tusd.balanceOf(address(wtusd)), 2_500_000 ether);
+        assertEq(IERC20(address(wtusd)).totalSupply(), 2_000_000 ether);
+
+        usdcet.transfer(BOB, 1_000_000 ether);
+        usdt.transfer(BOB, 1_000_000 ether);
+        assertEq(usdcet.balanceOf(BOB), 1_000_000 ether);
+        assertEq(usdt.balanceOf(BOB), 1_000_000 ether);
+        assertEq(tusd.balanceOf(BOB), 0);
+        assertEq(wtusd.balanceOf(BOB), 0);
+
+        // BOB mint tUSD and stake to WTUSD pool by StableAssetStakeUtil.mintAndStake
+        vm.startPrank(BOB);
+        usdcet.approve(address(util), 1_000_000 ether);
+        usdt.approve(address(util), 1_000_000 ether);
+        uint256[] memory amounts1 = new uint256[](2);
+        amounts1[0] = 1_000_000 ether;
+        amounts1[1] = 1_000_000 ether;
+        emit Stake(BOB, 0, 1_600_000 ether);
+        util.mintAndStake(1, amounts1, tusd, wtusd, 0);
+        vm.stopPrank();
+
+        assertEq(usdcet.balanceOf(BOB), 0);
+        assertEq(usdt.balanceOf(BOB), 0);
+        assertEq(tusd.balanceOf(BOB), 0);
+        assertEq(wtusd.balanceOf(BOB), 0);
+        assertEq(tusd.balanceOf(address(staking)), 0);
+        assertEq(wtusd.balanceOf(address(staking)), 3_600_000 ether);
+        assertEq(tusd.balanceOf(address(wtusd)), 4_500_000 ether);
+        assertEq(IERC20(address(wtusd)).totalSupply(), 3_600_000 ether);
+    }
+}

--- a/test/WrappedTUSD.t.sol
+++ b/test/WrappedTUSD.t.sol
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "@openzeppelin-contracts/token/ERC20/IERC20.sol";
+import "./MockToken.sol";
+import "../src/WrappedTUSD.sol";
+
+contract WTUSDTest is Test {
+    WrappedTUSD public wtusd;
+    IERC20 public tusd;
+    address public ALICE = address(0x1111);
+    address public BOB = address(0x2222);
+
+    event Deposit(address indexed who, uint256 tusdAmount, uint256 wtusdAmount);
+    event Withdraw(address indexed who, uint256 wtusdAmount, uint256 tusdAmount);
+
+    function setUp() public {
+        vm.prank(ALICE);
+        tusd = IERC20(address(new MockToken("Taiga tUSD", "tUSD", 1_000_000_000 ether)));
+        wtusd = new WrappedTUSD(address(tusd));
+    }
+
+    function test_depositRate_noWTUSDIssued() public {
+        assertEq(wtusd.depositRate(), 1e18);
+        assertEq(wtusd.totalSupply(), 0);
+        assertEq(tusd.balanceOf(address(wtusd)), 0);
+
+        vm.prank(ALICE);
+        tusd.transfer(address(wtusd), 100 ether);
+        assertEq(wtusd.depositRate(), 1e18);
+        assertEq(wtusd.totalSupply(), 0);
+        assertEq(tusd.balanceOf(address(wtusd)), 100 ether);
+    }
+
+    function test_depositRate_noTUSDHold() public {
+        vm.startPrank(ALICE);
+        tusd.approve(address(wtusd), 100 ether);
+        wtusd.deposit(100 ether);
+        assertEq(wtusd.totalSupply(), 100 ether);
+        assertEq(tusd.balanceOf(address(wtusd)), 100 ether);
+        assertEq(wtusd.depositRate(), 1e18);
+
+        // mock no tusd hold
+        MockToken(address(tusd)).forceTransfer(address(wtusd), ALICE, 100 ether);
+        assertEq(wtusd.totalSupply(), 100 ether);
+        assertEq(tusd.balanceOf(address(wtusd)), 0);
+        assertEq(wtusd.depositRate(), 1e18);
+    }
+
+    function test_withdrawRate_noWTUSDIssued() public {
+        assertEq(wtusd.withdrawRate(), 0);
+        assertEq(wtusd.totalSupply(), 0);
+        assertEq(tusd.balanceOf(address(wtusd)), 0);
+
+        vm.prank(ALICE);
+        tusd.transfer(address(wtusd), 100 ether);
+        assertEq(wtusd.withdrawRate(), 0);
+        assertEq(wtusd.totalSupply(), 0);
+        assertEq(tusd.balanceOf(address(wtusd)), 100 ether);
+    }
+
+    function test_withdrawRate_noTUSDHold() public {
+        vm.startPrank(ALICE);
+        tusd.approve(address(wtusd), 100 ether);
+        wtusd.deposit(100 ether);
+        assertEq(wtusd.totalSupply(), 100 ether);
+        assertEq(tusd.balanceOf(address(wtusd)), 100 ether);
+        assertEq(wtusd.withdrawRate(), 1e18);
+
+        // mock no tusd hold
+        MockToken(address(tusd)).forceTransfer(address(wtusd), ALICE, 100 ether);
+        assertEq(wtusd.totalSupply(), 100 ether);
+        assertEq(tusd.balanceOf(address(wtusd)), 0);
+        assertEq(wtusd.withdrawRate(), 0);
+    }
+
+    function test_deposit_works() public {
+        // ALICE deposit 100 TUSD to get 100 WTUSD
+        vm.startPrank(ALICE);
+        tusd.approve(address(wtusd), 100 ether);
+        vm.expectEmit(true, false, false, true);
+        emit Deposit(ALICE, 100 ether, 100 ether);
+        assertEq(wtusd.deposit(100 ether), 100 ether);
+        assertEq(wtusd.totalSupply(), 100 ether);
+        assertEq(tusd.balanceOf(address(wtusd)), 100 ether);
+        assertEq(wtusd.balanceOf(ALICE), 100 ether);
+        assertEq(tusd.balanceOf(ALICE), 999_999_900 ether);
+
+        tusd.transfer(BOB, 200 ether);
+        assertEq(wtusd.balanceOf(BOB), 0);
+        assertEq(tusd.balanceOf(BOB), 200 ether);
+        vm.stopPrank();
+
+        // BOB deposit 200 TUSD to get 200 WTUSD
+        vm.startPrank(BOB);
+        tusd.approve(address(wtusd), 200 ether);
+        vm.expectEmit(true, false, false, true);
+        emit Deposit(BOB, 200 ether, 200 ether);
+        assertEq(wtusd.deposit(200 ether), 200 ether);
+        assertEq(wtusd.totalSupply(), 300 ether);
+        assertEq(tusd.balanceOf(address(wtusd)), 300 ether);
+        assertEq(wtusd.balanceOf(BOB), 200 ether);
+        assertEq(tusd.balanceOf(BOB), 0);
+        vm.stopPrank();
+
+        // mock hold tusd increase 100 TUSD
+        vm.startPrank(ALICE);
+        tusd.transfer(address(wtusd), 100 ether);
+        assertEq(wtusd.totalSupply(), 300 ether);
+        assertEq(tusd.balanceOf(address(wtusd)), 400 ether);
+        assertEq(wtusd.balanceOf(ALICE), 100 ether);
+        assertEq(tusd.balanceOf(ALICE), 999_999_600 ether);
+
+        // ALICE deposit 100 TUSD to get 75 WTUSD
+        tusd.approve(address(wtusd), 100 ether);
+        vm.expectEmit(true, false, false, true);
+        emit Deposit(ALICE, 100 ether, 75 ether);
+        assertEq(wtusd.deposit(100 ether), 75 ether);
+        assertEq(wtusd.totalSupply(), 375 ether);
+        assertEq(tusd.balanceOf(address(wtusd)), 500 ether);
+        assertEq(wtusd.balanceOf(ALICE), 175 ether);
+        assertEq(tusd.balanceOf(ALICE), 999_999_500 ether);
+    }
+
+    function test_withdraw_revertNotEnough() public {
+        vm.startPrank(ALICE);
+        vm.expectRevert("WTUSD: WTUSD not enough");
+        wtusd.withdraw(1_000 ether);
+    }
+
+    function test_withdraw_works() public {
+        vm.startPrank(ALICE);
+        tusd.approve(address(wtusd), 1000 ether);
+        wtusd.deposit(1_000 ether);
+        assertEq(wtusd.totalSupply(), 1_000 ether);
+        assertEq(tusd.balanceOf(address(wtusd)), 1_000 ether);
+        assertEq(wtusd.balanceOf(ALICE), 1_000 ether);
+        assertEq(tusd.balanceOf(ALICE), 999_999_000 ether);
+
+        // ALICE withdraw 100 WTUSD to get 100 TUSD
+        vm.expectEmit(true, false, false, true);
+        emit Withdraw(ALICE, 100 ether, 100 ether);
+        assertEq(wtusd.withdraw(100 ether), 100 ether);
+        assertEq(wtusd.totalSupply(), 900 ether);
+        assertEq(tusd.balanceOf(address(wtusd)), 900 ether);
+        assertEq(wtusd.balanceOf(ALICE), 900 ether);
+        assertEq(tusd.balanceOf(ALICE), 999_999_100 ether);
+
+        wtusd.transfer(BOB, 500 ether);
+        assertEq(wtusd.balanceOf(BOB), 500 ether);
+        assertEq(tusd.balanceOf(BOB), 0);
+        vm.stopPrank();
+
+        // BOB withdraw 100 WTUSD to get 100 TUSD
+        vm.prank(BOB);
+        vm.expectEmit(true, false, false, true);
+        emit Withdraw(BOB, 100 ether, 100 ether);
+        assertEq(wtusd.withdraw(100 ether), 100 ether);
+        assertEq(wtusd.totalSupply(), 800 ether);
+        assertEq(tusd.balanceOf(address(wtusd)), 800 ether);
+        assertEq(wtusd.balanceOf(BOB), 400 ether);
+        assertEq(tusd.balanceOf(BOB), 100 ether);
+
+        // mock hold tusd increase 200 TUSD
+        vm.prank(ALICE);
+        tusd.transfer(address(wtusd), 200 ether);
+        assertEq(wtusd.totalSupply(), 800 ether);
+        assertEq(tusd.balanceOf(address(wtusd)), 1_000 ether);
+
+        // BOB withdraw 100 WTUSD to get TUSD
+        vm.prank(BOB);
+        vm.expectEmit(true, false, false, true);
+        emit Withdraw(BOB, 100 ether, 125 ether);
+        assertEq(wtusd.withdraw(100 ether), 125 ether);
+        assertEq(wtusd.totalSupply(), 700 ether);
+        assertEq(tusd.balanceOf(address(wtusd)), 875 ether);
+        assertEq(wtusd.balanceOf(BOB), 300 ether);
+        assertEq(tusd.balanceOf(BOB), 225 ether);
+
+        // mock no tusd hold
+        MockToken(address(tusd)).forceTransfer(address(wtusd), ALICE, 875 ether);
+        assertEq(wtusd.totalSupply(), 700 ether);
+        assertEq(tusd.balanceOf(address(wtusd)), 0);
+
+        vm.startPrank(BOB);
+        vm.expectRevert("WTUSD: invalid TUSD amount");
+        wtusd.withdraw(100 ether);
+    }
+}


### PR DESCRIPTION
`UpgradeableStakingLSTV2` stake dot not convert TDOT when pool's current shareType is WTDOT, and unstake dot not convert WTDOT back to TDOT. Use `StableAssetStakeUtil` to batch these operations